### PR TITLE
server.Servers struct :  fix server.Servers can be nil and it shouldn't

### DIFF
--- a/cmd/pixicoreAPI/main.go
+++ b/cmd/pixicoreAPI/main.go
@@ -30,7 +30,10 @@ func main() {
 	// receive notifications of the specified signals.
 	signal.Notify(sigs, syscall.SIGINT, syscall.SIGTERM)
 
-	myConfigFile := config.InitConfig()
+	myConfigFile, err := config.InitConfig()
+	if err != nil {
+		log.Fatalln(err)
+	}
 	controller := api.InitController(myConfigFile)
 
 	go func() {

--- a/pkg/api/controller_test.go
+++ b/pkg/api/controller_test.go
@@ -13,22 +13,21 @@ import (
 
 // Helper function to process a request and test its response
 func testHTTPResponse(t *testing.T, r *gin.Engine, req *http.Request, f func(w *httptest.ResponseRecorder) bool) {
-
 	// Create a response recorder
 	w := httptest.NewRecorder()
 
 	// Create the service and process the above request.
 	r.ServeHTTP(w, req)
-
 	if !f(w) {
 		t.Fail()
+
 	}
 }
 
 func TestGetServers(t *testing.T) {
 	myConfigFile, err := config.InitConfig()
 	if err != nil {
-		t.Errorf("Error from InitConfig come normally from a broken configFile. TODO : Test env. must be sandboxed. Then config must be mocked.")
+		t.Errorf("An error from InitConfig usually comes from a broken configFile. TODO : Test env. must be sandboxed. Then config must be mocked.")
 	}
 
 	controller := InitController(myConfigFile)
@@ -45,5 +44,4 @@ func TestGetServers(t *testing.T) {
 
 		return statusOK && pageOK
 	})
-
 }

--- a/pkg/api/controller_test.go
+++ b/pkg/api/controller_test.go
@@ -26,7 +26,11 @@ func testHTTPResponse(t *testing.T, r *gin.Engine, req *http.Request, f func(w *
 }
 
 func TestGetServers(t *testing.T) {
-	myConfigFile := config.InitConfig()
+	myConfigFile, err := config.InitConfig()
+	if err != nil {
+		t.Errorf("Error from InitConfig come normally from a broken configFile. TODO : Test env. must be sandboxed. Then config must be mocked.")
+	}
+
 	controller := InitController(myConfigFile)
 	r := GetRouter(controller)
 

--- a/pkg/api/controllers.go
+++ b/pkg/api/controllers.go
@@ -26,7 +26,6 @@ func (ctrl *Controller) Getlocal(c *gin.Context) {
 func (ctrl *Controller) BootServer(c *gin.Context) {
 
 	servers, err := ctrl.currentConfig.GetServers()
-
 	if err != nil {
 		log.Warn(err)
 	}
@@ -79,7 +78,7 @@ func (ctrl *Controller) InstallAll(c *gin.Context) {
 	c.JSON(200, &servers)
 }
 
-//CollectServerInfo collect information about a server with ssh
+// CollectServerInfo collect information about a server with ssh
 func (ctrl *Controller) CollectServerInfo(c *gin.Context) *server.Server {
 
 	currentServer := (*ctrl.currentConfig.Servers)[c.Param("macAddress")]
@@ -128,7 +127,7 @@ func (ctrl *Controller) CollectServerInfo(c *gin.Context) *server.Server {
 
 }
 
-//GetServers return config of the all the servers
+// GetServers return config of the all the servers
 func (ctrl *Controller) GetServers(c *gin.Context) {
 	servers, err := ctrl.currentConfig.GetServers()
 

--- a/pkg/api/initApi.go
+++ b/pkg/api/initApi.go
@@ -12,7 +12,7 @@ func InitController(confFile *config.ConfigFile) Controller {
 	return ctrl
 }
 
-//Cors cors for the api
+// Cors cors for the api
 func Cors() gin.HandlerFunc {
 	return func(c *gin.Context) {
 		c.Writer.Header().Add("Access-Control-Allow-Origin", "*")

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -57,30 +57,35 @@ func (configFile *ConfigFile) WriteYamlConfig() {
 
 //ReadConfig read the yaml config file
 func (configFile *ConfigFile) ReadYamlConfig() (error) {
-	filename, _ := filepath.Abs(configFile.Path)
-
-	yamlFile, err := ioutil.ReadFile(filename)
-	if err != nil {
-		return err
-	}
-
-	// If the config file are empty, make a new servers list
-	if len(yamlFile) == 0 {
-		log.Infoln("Configfile named ", filename, " are actually empty. Init servers list in-memory")
+	// If the config does not exist
+	if _, err := os.Stat(configFile.Path); os.IsNotExist(err) {
+		log.Infoln("Configfile in does not exist . Init servers list in-memory")
 		emptyServers := make(server.Servers)
 		configFile.Servers = &emptyServers
-
-	//If the config file are not empty, do more checks to load his content
+		//If the config file are not empty, do more checks to load his content
 	} else {
 
-		// Try to parse the config file as a server list
-		err = yaml.Unmarshal(yamlFile, &configFile.Servers)
+		filename, _ := filepath.Abs(configFile.Path)
+
+		yamlFile, err := ioutil.ReadFile(filename)
 		if err != nil {
 			return err
 		}
+		//if cofig file is empty create and use servers in memory
+		if len(yamlFile) == 0 {
+			emptyServers := make(server.Servers)
+			configFile.Servers = &emptyServers
+		} else {
+			// Try to parse the config file as a server list
+			err = yaml.Unmarshal(yamlFile, &configFile.Servers)
+			if err != nil {
+				log.Infoln("corrupted config file")
+				return err
+			}
 
+		}
 		// if the server list are nil in the config file, make a new list of servers
-		if  *configFile.Servers == nil {
+		if *configFile.Servers == nil {
 			emptyServers := make(server.Servers)
 			configFile.Servers = &emptyServers
 		}

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -57,26 +57,22 @@ func (configFile *ConfigFile) WriteYamlConfig() {
 
 //ReadConfig read the yaml config file
 func (configFile *ConfigFile) ReadYamlConfig() (error) {
-	// If the config does not exist
-	if _, err := os.Stat(configFile.Path); os.IsNotExist(err) {
-		log.Infoln("Configfile in does not exist . Init servers list in-memory")
-		emptyServers := make(server.Servers)
-		configFile.Servers = &emptyServers
-		//If the config file are not empty, do more checks to load his content
-	} else {
+
+	// Config file exist 
+	if _, err := os.Stat(configFile.Path); !os.IsNotExist(err) {
 
 		filename, _ := filepath.Abs(configFile.Path)
-
 		yamlFile, err := ioutil.ReadFile(filename)
 		if err != nil {
 			return err
 		}
-		//if cofig file is empty create and use servers in memory
+
+		// Config file is empty, create and use servers list in memory
 		if len(yamlFile) == 0 {
 			emptyServers := make(server.Servers)
 			configFile.Servers = &emptyServers
 		} else {
-			// Try to parse the config file as a server list
+			// Try to parse the Config file as a server list
 			err = yaml.Unmarshal(yamlFile, &configFile.Servers)
 			if err != nil {
 				log.Infoln("corrupted config file")
@@ -84,11 +80,18 @@ func (configFile *ConfigFile) ReadYamlConfig() (error) {
 			}
 
 		}
-		// if the server list are nil in the config file, make a new list of servers
+		// Server list are nil in config file, make a new list of servers
 		if *configFile.Servers == nil {
 			emptyServers := make(server.Servers)
 			configFile.Servers = &emptyServers
 		}
+
+	// Config file does not exist. Initing servers list in memory.
+	} else {
+
+		log.Infoln("Config file does not exist. Initing servers list in-memory.")
+		emptyServers := make(server.Servers)
+		configFile.Servers = &emptyServers
 	}
 	return nil
 }

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -16,7 +16,7 @@ type ConfigFile struct {
 	Path    string
 }
 
-//InitConfig create config if it does not exist
+// InitConfig create config if it does not exist
 func InitConfig() (*ConfigFile, error) {
 	filePath := "servers-config.yaml"
 
@@ -29,15 +29,14 @@ func InitConfig() (*ConfigFile, error) {
 	case *os.PathError:
 		log.Warnln(err)
 		return confFile, nil
-	// for all unmanaged kind of errors
+	// For all unmanaged kind of errors
 	default:
 		return nil, err
 	}
 }
 
-//WriteConfig write the yaml config file
+// WriteConfig write the yaml config file
 func (configFile *ConfigFile) WriteYamlConfig() {
-
 	if _, err := os.Stat(configFile.Path); os.IsNotExist(err) {
 		f, err := os.Create(configFile.Path)
 		log.Fatalln(err)
@@ -55,10 +54,10 @@ func (configFile *ConfigFile) WriteYamlConfig() {
 	f.Close()
 }
 
-//ReadConfig read the yaml config file
-func (configFile *ConfigFile) ReadYamlConfig() (error) {
+// ReadConfig read the yaml config file
+func (configFile *ConfigFile) ReadYamlConfig() error {
 
-	// Config file exist 
+	// Config file exist
 	if _, err := os.Stat(configFile.Path); !os.IsNotExist(err) {
 
 		filename, _ := filepath.Abs(configFile.Path)
@@ -66,7 +65,6 @@ func (configFile *ConfigFile) ReadYamlConfig() (error) {
 		if err != nil {
 			return err
 		}
-
 		// Config file is empty, create and use servers list in memory
 		if len(yamlFile) == 0 {
 			emptyServers := make(server.Servers)
@@ -86,9 +84,8 @@ func (configFile *ConfigFile) ReadYamlConfig() (error) {
 			configFile.Servers = &emptyServers
 		}
 
-	// Config file does not exist. Initing servers list in memory.
 	} else {
-
+		// Config file does not exist. Initing servers list in memory.
 		log.Infoln("Config file does not exist. Initing servers list in-memory.")
 		emptyServers := make(server.Servers)
 		configFile.Servers = &emptyServers
@@ -96,7 +93,7 @@ func (configFile *ConfigFile) ReadYamlConfig() (error) {
 	return nil
 }
 
-//GetServers return config of the all the servers
+// GetServers return config of the all the servers
 func (configFile *ConfigFile) GetServers() (*server.Servers, error) {
 	log.Info(configFile)
 

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -25,15 +25,14 @@ func InitConfig() (*ConfigFile, error) {
 	err := confFile.ReadYamlConfig()
 	switch err.(type) {
 	case nil:
-		break
+		return confFile, nil
 	case *os.PathError:
 		log.Warnln(err)
-		break
-	case error:
+		return confFile, nil
+	// for all unmanaged kind of errors
+	default:
 		return nil, err
 	}
-
-	return confFile, nil
 }
 
 //WriteConfig write the yaml config file

--- a/pkg/helper/helpers.go
+++ b/pkg/helper/helpers.go
@@ -19,7 +19,6 @@ type PxeSpec struct {
 
 //// *************************** HELPER FUNCTIONS ****************************
 func PixicoreInit(IPAddress string) PxeSpec {
-
 	cmd := "coreos.autologin coreos.first_boot=1 coreos.config.url={{ URL \"file:///home/cedille/pxe-config.ign\" }}"
 	ip := "ip="
 	ip = strings.Join([]string{ip, IPAddress}, "")
@@ -36,7 +35,7 @@ func PixicoreInit(IPAddress string) PxeSpec {
 	return pxeSpec
 }
 
-//CollectPhysicalsIfaces Used to collect physicals interfaces by excluding virtuals interfaces from all interfaces
+// CollectPhysicalsIfaces Used to collect physicals interfaces by excluding virtuals interfaces from all interfaces
 func CollectPhysicalsIfaces() ([]*net.Interface, error) {
 	// Use system path containing all interfaces
 	// Since everything is a file on *Nix systems we can only use /sys to discover nic.

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -33,7 +33,7 @@ type NilServerListError struct {
 }
 
 func (e *NilServerListError) Error() string {
-	return fmt.Sprintf("%v: server error", "Server list are nil and maps in golang are useless when they are nil. Reference : https://blog.golang.org/go-maps-in-action")
+	return fmt.Sprintf("%v: server error", "Server list is nil and maps in Golang are useless when they are nil. Reference : https://blog.golang.org/go-maps-in-action")
 }
 
 type UnreconizeServerError struct {

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -33,7 +33,7 @@ type NilServerListError struct {
 }
 
 func (e *NilServerListError) Error() string {
-	return fmt.Sprintf("%v: server error", "Server list are nil")
+	return fmt.Sprintf("%v: server error", "Server list are nil and maps in golang are useless when they are nil. Reference : https://blog.golang.org/go-maps-in-action")
 }
 
 type UnreconizeServerError struct {
@@ -66,7 +66,11 @@ func (servers *Servers) AddServer(macAddressStr string) error {
 		case *UnreconizeServerError:
 			break
 		case *NilServerListError:
+
+			// A map should not be nil
+			// Refence : https://blog.golang.org/go-maps-in-action
 			return err
+
 		default:
 			return err
 		}
@@ -99,7 +103,6 @@ func (servers *Servers) GetServer(macAddressStr string) (*Server, error) {
 		return nil, new(EmptyServerListError)
 
 	} else if server, ok := (*servers)[macAddressStr]; ok {
-		fmt.Print("MYSERVER", server)
 		return server, nil
 	} else {
 		err := UnreconizeServerError{serverList: servers, wantedServer: macAddressStr}


### PR DESCRIPTION
FIX: remove the case where servers can be nil at config file loading
FIX: centralize config file load on config.ReadYamlConfig()